### PR TITLE
disable swagger-validate action temporarily

### DIFF
--- a/.github/workflows/reusable-swagger-validate-workflow.yaml
+++ b/.github/workflows/reusable-swagger-validate-workflow.yaml
@@ -38,6 +38,7 @@ jobs:
 
             - name: Validate OpenAPI definition
               uses: swaggerexpert/swagger-editor-validate@v1
+              continue-on-error: true
               with:
-                  swagger-editor-url: https://editor.swagger.io/ # http://localhost:80/
+                  # swagger-editor-url: https://editor.swagger.io/ # http://localhost:80/
                   definition-file: ${{ matrix.file }}


### PR DESCRIPTION
Due to persistent error in the workflow we'd disable this workflow temporarily and return success even on validation issue 

```
Error: Error while validating in Swagger Editor
Error: TimeoutError: Waiting for selector `.info .main .title` failed: Waiting failed: 10000ms exceeded
Error: Process completed with exit code 1.
```